### PR TITLE
fix(core): unwrap double-wrapped object parameters from MCP SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,21 +25,19 @@
 
 ## Overview
 
-This extension provides a plug-and-play integration between LoopBack4 applications and the Model Context Protocol (MCP) specification.
-
-Its purpose is to enable LoopBack APIs, services, and business logic to be exposed as MCP Tools, allowing external MCP clients (such as LLMs, agents, or MCP-compatible apps) to discover and execute server-defined operations.
+This extension provides a plug-and-play integration between LoopBack4 applications and Model Context Protocol (MCP) specification. Its purpose is to enable LoopBack APIs, services, and business logic to be exposed as MCP Tools, allowing external MCP clients (such as LLMs, agents, or MCP-compatible apps) to discover and execute server-defined operations.
 
 ### Key Features
 
-- Automatic MCP Tool Discovery :-
-  The extension scans your application at boot time and automatically registers all methods decorated with the custom @mcpTool() decorator.
+- **Automatic MCP Tool Discovery**: The extension scans your application at boot time and automatically registers all methods decorated with the custom `@mcpTool()` decorator. This allows you to define MCP tools anywhere in your LoopBack project without manually wiring metadata.
 
-  This allows you to define MCP tools anywhere in your LoopBack project without manually wiring metadata.
+- **Lifecycle-managed Tool Registry**: A dedicated `McpToolRegistry` service maintains all discovered tool metadata, their handlers, and execution context. A `McpToolRegistryBootObserver` ensures that registration happens only after the application has fully booted.
 
-- Lifecycle-managed Tool Registry :-
-  A dedicated `McpToolRegistry` service maintains all discovered tool metadata,their handlers and execution context.
+- **Hook System Support**: Built-in support for pre and post hooks that enable validation, logging, audit trails, and custom business logic around tool execution.
 
-  A `McpToolRegistryBootObserver` ensures that registration happens only after the application has fully booted.
+- **Authorization Integration**: Seamless integration with LoopBack's authorization system, ensuring MCP tools respect your existing permission structure.
+
+- **Simplified Endpoint Format**: Easy-to-use POST endpoint that accepts tool arguments directly without complex MCP protocol wrapping.
 
 ## Installation
 
@@ -47,89 +45,530 @@ Its purpose is to enable LoopBack APIs, services, and business logic to be expos
 npm install loopback4-mcp
 ```
 
-## Basic Usage
+## Integration Steps
 
-Configure and load `McpComponent` in the application constructor
-as shown below.
+### Step 1: Create Binding Keys
 
-```ts
-import {McpComponent} from 'loopback4-mcp';
+Create a `src/keys.ts` file to define binding keys for MCP hooks:
 
-export class MyApplication extends BootMixin(
-  ServiceMixin(RepositoryMixin(RestApplication)),
-) {
-  constructor(options: ApplicationConfig = {}) {
-    super();
-    this.component(McpComponent);
+```typescript
+import {BindingKey} from '@loopback/core';
+
+export namespace McpHookBindings {
+  export const PRE_HOOK = BindingKey.create<Function>('hooks.mcp.preHook');
+  export const POST_HOOK = BindingKey.create<Function>('hooks.mcp.postHook');
+}
+```
+
+### Step 2: Create Hook Providers
+
+Create hook providers to implement pre and post-hook functionality:
+
+```typescript
+// src/providers/mcp-pre-hook.provider.ts
+import {inject, Provider} from '@loopback/core';
+import {McpHookContext} from 'loopback4-mcp';
+
+export class McpPreHookProvider implements Provider<Function> {
+  value(): Function {
+    return async (context: McpHookContext) => {
+      console.log(`Pre-hook executing for tool: ${context.toolName}`);
+      // Add validation, sanitization, or pre-processing logic here
+    };
   }
 }
-```
 
-Add the `@mcpTool()` decorator to any controller in your application.
-
-All MCP tool methods must use LoopBack `@param` decorators to define their input parameters.If `@param` decorators are missing, the MCP tool will fail.
-
-```ts
-@mcpTool({
-  name: 'create-user',
-  description: 'Creates a new user in the system',
-  schema?: {
-    email: z.string().email(),
-    name: z.string(),
-  },
-})
-async createUser(
-  @param.query.string('email') email: string,
-  @param.query.string('name') name: string,
-) {
-  return {message: `User ${name} created`};
-}
-```
-
-This decorator accepts a total of five fields, out of which `name` and `description` are mandatory and `schema`,`preHook` and `postHook` are optional enhancements.
-
-The schema field allows defining a Zod-based validation schema for tool input parameters, while preHook and postHook enable execution of custom logic before and after the tool handler runs.
-
-## Mcp Hook Usage Details
-
-To use hooks with MCP tools, follow the provider-based approach:
-
-Step 1: Create a hook provider:
-
-```ts
-// src/providers/my-hook.provider.ts
-export class MyHookProvider implements Provider<McpHookFunction> {
-  constructor(@inject(LOGGER.LOGGER_INJECT) private logger: ILogger) {}
-  value(): McpHookFunction {
+// src/providers/mcp-post-hook.provider.ts
+export class McpPostHookProvider implements Provider<Function> {
+  value(): Function {
     return async (context: McpHookContext) => {
-      this.logger.info(`Hook executed for tool: ${context.toolName}`);
+      console.log(`Post-hook executing for tool: ${context.toolName}`);
+      // Add logging, audit trails, or post-processing logic here
     };
   }
 }
 ```
 
-Step 2: Add binding key to McpHookBindings:
+### Step 3: Configure Application
 
-```ts
-// src/keys.ts
-export namespace McpHookBindings {
-  export const MY_HOOK = BindingKey.create<McpHookFunction>('hooks.mcp.myHook');
+Update your `src/application.ts` to bind the component and hooks:
+
+```typescript
+import {BootMixin, ServiceMixin} from '@loopback/core';
+import {RepositoryMixin, RestApplication} from '@loopback/rest';
+import {McpComponent} from 'loopback4-mcp';
+import {McpHookBindings} from './keys';
+import {McpPreHookProvider} from './providers/mcp-pre-hook.provider';
+import {McpPostHookProvider} from './providers/mcp-post-hook.provider';
+
+export class MyApplication extends BootMixin(
+  ServiceMixin(RepositoryMixin(RestApplication)),
+) {
+  constructor(options: ApplicationConfig = {}) {
+    super(options);
+
+    // Bind MCP component
+    this.component(McpComponent);
+
+    // Bind hook providers
+    this.bind(McpHookBindings.PRE_HOOK).toProvider(McpPreHookProvider);
+    this.bind(McpHookBindings.POST_HOOK).toProvider(McpPostHookProvider);
+  }
 }
 ```
 
-Step 3: Bind provider in `application.ts`:
+### Step 4: Create MCP Tool Controllers
+
+Add the `@mcpTool()` decorator to controller methods you want to expose as MCP tools. Here's a complete example showing the decorator stack with authorization and authentication:
 
 ```typescript
-this.bind(McpHookBindings.MY_HOOK).toProvider(MyHookProvider);
+import {
+  Count,
+  CountSchema,
+  Filter,
+  repository,
+  Where,
+} from '@loopback/repository';
+import {param, post, get, patch, put, del, requestBody} from '@loopback/rest';
+import {authorize} from 'loopback4-authorization';
+import {authenticate, STRATEGY} from 'loopback4-authentication';
+import {PermissionKey} from '../permissions';
+import {
+  OPERATION_SECURITY_SPEC,
+  STATUS_CODE,
+  getModelSchemaRefSF,
+} from '@sourceloop/core';
+import {mcpTool} from 'loopback4-mcp';
+import {HookBindings} from '../keys';
+import {User, UserRepository} from '../models';
+
+export class UserController {
+  constructor(
+    @repository(UserRepository)
+    public userRepository: UserRepository,
+  ) {}
+
+  @authorize({
+    permissions: [PermissionKey.CreateUser],
+  })
+  @authenticate(STRATEGY.BEARER, {
+    passReqToCallback: true,
+  })
+  @mcpTool({
+    name: 'createUser',
+    description: 'Create a new user in the system',
+    preHook: {binding: HookBindings.PRE_HOOK},
+    postHook: {binding: HookBindings.POST_HOOK},
+  })
+  @post('/users', {
+    security: OPERATION_SECURITY_SPEC,
+    responses: {
+      [STATUS_CODE.OK]: {
+        description: 'User model instance',
+        content: {
+          'application/json': {schema: getModelSchemaRefSF(User)},
+        },
+      },
+    },
+  })
+  async create(
+    @param.query.object('user') user: Omit<User, 'id'>,
+  ): Promise<object> {
+    const created = await this.userRepository.create(user as User);
+
+    return {
+      content: [{
+        type: 'text',
+        text: `Successfully created user with id: ${created.id}`
+      }]
+    };
+  }
+
+  @authorize({
+    permissions: [PermissionKey.ViewUser],
+  })
+  @authenticate(STRATEGY.BEARER, {
+    passReqToCallback: true,
+  })
+  @mcpTool({
+    name: 'getUserById',
+    description: 'Get a user by ID',
+    preHook: {binding: HookBindings.PRE_HOOK},
+    postHook: {binding: HookBindings.POST_HOOK},
+  })
+  @get('/users/{id}', {
+    security: OPERATION_SECURITY_SPEC,
+    responses: {
+      [STATUS_CODE.OK]: {
+        description: 'User model instance',
+        content: {
+          'application/json': {
+            schema: getModelSchemaRefSF(User, {includeRelations: true}),
+          },
+        },
+      },
+    },
+  })
+  async findById(
+    @param.path.string('id') id: string,
+  ): Promise<User> {
+    return this.userRepository.findById(id);
+  }
+
+  @authorize({
+    permissions: [PermissionKey.ViewUser],
+  })
+  @authenticate(STRATEGY.BEARER, {
+    passReqToCallback: true,
+  })
+  @mcpTool({
+    name: 'listUsers',
+    description: 'List all users',
+    preHook: {binding: HookBindings.PRE_HOOK},
+    postHook: {binding: HookBindings.POST_HOOK},
+  })
+  @get('/users', {
+    security: OPERATION_SECURITY_SPEC,
+    responses: {
+      [STATUS_CODE.OK]: {
+        description: 'Array of User model instances',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'array',
+              items: getModelSchemaRefSF(User, {includeRelations: true}),
+            },
+          },
+        },
+      },
+    },
+  })
+  async find(
+    @param.filter(User) filter?: Filter<User>,
+  ): Promise<User[]> {
+    return this.userRepository.find(filter);
+  }
+
+  @authorize({
+    permissions: [PermissionKey.UpdateUser],
+  })
+  @authenticate(STRATEGY.BEARER, {
+    passReqToCallback: true,
+  })
+  @mcpTool({
+    name: 'updateUserById',
+    description: 'Update a user by ID',
+    preHook: {binding: HookBindings.PRE_HOOK},
+    postHook: {binding: HookBindings.POST_HOOK},
+  })
+  @patch('/users/{id}', {
+    security: OPERATION_SECURITY_SPEC,
+    responses: {
+      [STATUS_CODE.NO_CONTENT]: {
+        description: 'User PATCH success',
+      },
+    },
+  })
+  async updateById(
+    @param.path.string('id') id: string,
+    @param.query.object('user') user: User,
+  ): Promise<object> {
+    await this.userRepository.updateById(id, user);
+
+    return {
+      content: [{
+        type: 'text',
+        text: `Successfully updated user with id: ${id}`
+      }]
+    };
+  }
+
+  @authorize({
+    permissions: [PermissionKey.DeleteUser],
+  })
+  @authenticate(STRATEGY.BEARER, {
+    passReqToCallback: true,
+  })
+  @mcpTool({
+    name: 'deleteUser',
+    description: 'Delete a user by ID',
+    preHook: {binding: HookBindings.PRE_HOOK},
+    postHook: {binding: HookBindings.POST_HOOK},
+  })
+  @del('/users/{id}', {
+    security: OPERATION_SECURITY_SPEC,
+    responses: {
+      [STATUS_CODE.NO_CONTENT]: {
+        description: 'User DELETE success',
+      },
+    },
+  })
+  async deleteById(@param.path.string('id') id: string): Promise<object> {
+    // Verify user exists first (will throw 404 if not found)
+    await this.userRepository.findById(id);
+
+    await this.userRepository.deleteById(id);
+
+    return {
+      content: [{
+        type: 'text',
+        text: `Successfully deleted user with id: ${id}`
+      }]
+    };
+  }
+}
 ```
 
-Step 4: Use in decorator:
+## Component Interaction Flow
 
-```ts
+**Request Flow:**
+```
+Client Request (POST /mcp?tool=toolName)
+                    ↓
+McpController receives request and creates MCP server
+                    ↓
+McpServerFactory generates per-request server instance
+                    ↓
+McpToolRegistry looks up tool by name
+                    ↓
+Authorization Check validates JWT and permissions
+                    ↓
+Pre-Hook (if configured) performs validation/sanitization
+                    ↓
+Controller Method executes business logic
+                    ↓
+Post-Hook (if configured) performs logging/audit trails
+                    ↓
+Response Formatting wraps result in MCP format
+                    ↓
+Client receives MCP-formatted response
+```
+
+**Error Flow:**
+```
+Authorization Check Failed → 403 Forbidden Response → Client receives error
+Controller Method Error → Error Formatting → Client receives MCP-formatted error
+Hook Execution Error → Error Handling → Client receives MCP-formatted error
+```
+
+## MCP Endpoint Usage
+
+### Endpoint Format
+
+**POST** `/mcp?tool=toolName`
+
+**Required Headers:**
+- `Content-Type: application/json`
+- `Authorization: Bearer YOUR_JWT_TOKEN`
+
+### Example Request
+
+```bash
+curl -X POST http://localhost:3000/mcp?tool=create-user \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN" \
+  -d '{
+    "user": {
+      "email": "john@example.com",
+      "name": "John Doe",
+      "age": 30
+    }
+  }'
+```
+
+### Example Response
+
+```json
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "User created with ID: 550e8400-e29b-41d4-a716-446655440000"
+    }
+  ]
+}
+```
+
+## Parameter Decorator Guidelines
+
+**Critical:** Use correct LoopBack `@param` decorators based on your route structure.
+
+### Path Parameters
+```typescript
+@get('/users/{id}')
+async findById(
+  @param.path.string('id') id: string,  // ✅ Correct for /users/{id}
+): Promise<User> {
+  return this.userRepository.findById(id);
+}
+```
+
+### Query Parameters
+```typescript
+@get('/users')
+async findAll(
+  @param.query.string('name') name?: string,  // ✅ Correct for /users?name=value
+): Promise<User[]> {
+  return this.userRepository.find({where: {name}});
+}
+```
+
+### Request Body Parameters
+```typescript
+@post('/users')
+async create(
+  @param.request.body('user') user: User,  // ✅ Correct for POST body
+): Promise<User> {
+  return this.userRepository.create(user);
+}
+```
+
+**Common Mistakes:**
+- ❌ Using `@param.query.string('id')` for `/users/{id}` routes
+- ✅ Use `@param.path.string('id')` for path parameters
+
+## Decorator Configuration
+
+The `@mcpTool()` decorator accepts the following configuration:
+
+```typescript
 @mcpTool({
- name: 'my-tool',
- description: 'my-description'
- preHookBinding: McpHookBindings.MY_HOOK,
-  postHookBinding: 'hooks.mcp.myOtherHook' // or string binding key
+  // Required fields
+  name: 'tool-name',              // Unique identifier for the tool
+  description: 'Tool description',  // Human-readable description
+
+  // Optional fields
+  schema: {                         // Zod validation schema
+    email: z.string().email(),
+    age: z.number().min(18),
+  },
+  preHookBinding: BindingKey.create('hooks.pre'),  // Pre-hook binding key
+  postHookBinding: BindingKey.create('hooks.post'), // Post-hook binding key
 })
 ```
+
+## Testing
+
+### Using MCP Inspector
+
+The easiest way to test and visualize your MCP tools is using the MCP Inspector. This provides a web interface where all your endpoints are available and you can see hook responses in real-time.
+
+**Start MCP Inspector:**
+```bash
+npx @modelcontextprotocol/inspector http://localhost:3000/mcp
+```
+
+**What MCP Inspector shows:**
+- **All Available Tools**: Complete list of MCP tools exposed by your application
+- **Tool Details**: Names, descriptions, and parameter schemas
+- **Live Testing**: Test each tool directly from the web interface
+- **Request/Response**: Real-time request and response data
+- **Hook Execution**: Visualize pre and post-hook execution and their responses
+- **Error Handling**: See error messages and debugging information
+
+**Workflow with MCP Inspector:**
+1. Start your LoopBack application
+2. Run MCP Inspector with your MCP endpoint URL
+3. Browse available tools in the web interface
+4. Test tools with different parameters
+5. Monitor hook execution and responses
+6. Debug issues using the detailed logs
+
+## Troubleshooting
+
+### Common Issues
+
+**Parameter extraction failures**
+- **Cause:** Missing or incorrect `@param` decorators
+- **Solution:** Ensure all parameters have appropriate decorators based on route structure
+
+**"Invalid tools/call result: expected object, received undefined"**
+- **Cause:** Method returns `void` instead of object
+- **Solution:** Always return explicit MCP-formatted response for non-read operations
+
+**Hook not executing**
+- **Cause:** Hook not bound in application.ts or binding key mismatch
+- **Solution:** Verify hook providers are bound and binding keys match decorator configuration
+
+**Authorization failures**
+- **Cause:** Missing `@authorize()` decorator or invalid JWT token
+- **Solution:** Add appropriate authorization decorators and ensure valid authentication
+
+## Best Practices
+
+1. **Always use `@param` decorators** - MCP tool will fail without them
+2. **Return MCP-formatted responses** for write operations (CREATE, UPDATE, DELETE)
+3. **Implement proper error handling** in controller methods and hooks
+4. **Use hooks for cross-cutting concerns** - validation, logging, audit trails
+5. **Test with curl first** before integrating with MCP clients
+6. **Monitor hook execution time** - hooks should be fast and non-blocking
+7. **Keep controller methods focused** - move complex logic to services
+8. **Use descriptive tool names** and detailed descriptions for better discovery
+
+## Advanced Features
+
+### Zod Schema Validation
+
+Add input validation using Zod schemas:
+
+```typescript
+import {z} from 'zod';
+
+@mcpTool({
+  name: 'create-user',
+  description: 'Create a new user',
+  schema: {
+    email: z.string().email('Invalid email format'),
+    name: z.string().min(2, 'Name must be at least 2 characters'),
+    age: z.number().min(18, 'User must be 18 or older'),
+  },
+})
+```
+
+### Custom Hook Implementations
+
+Create more sophisticated hooks for business logic:
+
+```typescript
+export class ValidationHookProvider implements Provider<Function> {
+  value(): Function {
+    return async (context: McpHookContext) => {
+      if (context.toolName === 'create-user') {
+        const user = context.args.user as any;
+
+        // Validate email uniqueness
+        const existing = await this.userRepository.findOne({
+          where: {email: user.email}
+        });
+
+        if (existing) {
+          throw new Error('User with this email already exists');
+        }
+
+        // Sanitize input
+        user.name = user.name.trim();
+        user.email = user.email.toLowerCase();
+      }
+    };
+  }
+}
+```
+
+## Complete Example
+
+For a complete working example, refer to the test suite in `src/__tests__/` which demonstrates:
+
+- Controller setup with `@mcpTool` decorators
+- Hook provider implementations
+- Integration with authorization system
+- Request/response handling
+- Error management
+
+## License
+
+[MIT](./LICENSE)
+
+## Support
+
+- GitHub Issues: [sourcefuse/loopback4-mcp/issues](https://github.com/sourcefuse/loopback4-mcp/issues)
+- Documentation: [loopback.io](https://loopback.io/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2895,14 +2895,14 @@
       }
     },
     "node_modules/@sourceloop/core/node_modules/loopback4-soft-delete": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/loopback4-soft-delete/-/loopback4-soft-delete-11.0.0.tgz",
-      "integrity": "sha512-MWBX+0W26us3v+VAb2uZOgkEaD4/P6Wt2shOhKnvN4lht8CccqItsUCcGPNEkzvvvcvJ+4magGI3VYd/3xlhAg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/loopback4-soft-delete/-/loopback4-soft-delete-11.1.0.tgz",
+      "integrity": "sha512-jA6d2t2PvaLdceTYf7K5AMzkZMTIoCOE/XLg3TWthI7zTln/oVZGJ8z2SwLxlagaXR/GOIWEK/LVYg0LR9p3wA==",
       "license": "MIT",
       "dependencies": {
-        "@loopback/core": "^7.0.3",
-        "@loopback/rest": "^15.0.4",
-        "lodash": "^4.17.21"
+        "@loopback/core": "^7.0.10",
+        "@loopback/rest": "^15.0.11",
+        "lodash": "^4.17.23"
       },
       "engines": {
         "node": ">=20"
@@ -9756,9 +9756,9 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/__tests__/integration/mcp-tool.integration.ts
+++ b/src/__tests__/integration/mcp-tool.integration.ts
@@ -14,7 +14,7 @@ describe('McpServerFactory (integration)', () => {
     {
       name: 'testTool',
       description: 'Test tool',
-      schema: z.object({}),
+      schema: {},
       handler: sinon.stub(),
     },
   ];

--- a/src/__tests__/integration/mcp-tool.integration.ts
+++ b/src/__tests__/integration/mcp-tool.integration.ts
@@ -5,6 +5,12 @@ import {McpToolRegistry} from '../../services/mcp-tool-registry.service';
 import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
 import {z} from 'zod';
 
+// Test constants to avoid magic numbers
+const TEST_NUMBER_1 = 1;
+const TEST_NUMBER_2 = 2;
+const TEST_NUMBER_3 = 3;
+const TEST_NUMBERS = [TEST_NUMBER_1, TEST_NUMBER_2, TEST_NUMBER_3];
+
 describe('McpServerFactory (integration)', () => {
   let ctx: Context;
   let toolRegistry: McpToolRegistry;
@@ -151,7 +157,7 @@ describe('McpServerFactory (integration)', () => {
 
       const arrayParams: Record<string, unknown> = {
         items: ['item1', 'item2', 'item3'],
-        numbers: [1, 2, 3],
+        numbers: TEST_NUMBERS,
       };
 
       for (const [key, value] of Object.entries(arrayParams)) {

--- a/src/__tests__/integration/mcp-tool.integration.ts
+++ b/src/__tests__/integration/mcp-tool.integration.ts
@@ -51,4 +51,148 @@ describe('McpServerFactory (integration)', () => {
       sinon.match.func,
     );
   });
+
+  describe('parameter unwrapping', () => {
+    it('unwraps double-wrapped object parameters', async () => {
+      const receivedParams: Record<string, unknown> = {};
+
+      // Simulate the unwrapping logic directly
+      const parameters = {
+        currency: {
+          currency: {
+            currencyCode: 'CAD',
+            currencyName: 'Canadian Dollar',
+            symbol: 'C$',
+            country: 'Canada',
+          },
+        },
+      };
+
+      // Apply the same unwrapping logic from the factory
+      for (const [key, value] of Object.entries(parameters)) {
+        if (value && typeof value === 'object') {
+          const valueObj = value as Record<string, unknown>;
+          if (key in valueObj && Object.keys(valueObj).length === 1) {
+            receivedParams[key] = valueObj[key];
+          } else {
+            receivedParams[key] = value;
+          }
+        } else {
+          receivedParams[key] = value;
+        }
+      }
+
+      expect(receivedParams).to.deepEqual({
+        currency: {
+          currencyCode: 'CAD',
+          currencyName: 'Canadian Dollar',
+          symbol: 'C$',
+          country: 'Canada',
+        },
+      });
+    });
+
+    it('keeps normal object parameters unchanged', () => {
+      const receivedParams: Record<string, unknown> = {};
+
+      const normalParams = {
+        currency: {
+          currencyCode: 'USD',
+          currencyName: 'US Dollar',
+          symbol: '$',
+          country: 'USA',
+        },
+        amount: 100,
+      };
+
+      for (const [key, value] of Object.entries(normalParams)) {
+        if (value && typeof value === 'object') {
+          const valueObj = value as Record<string, unknown>;
+          if (key in valueObj && Object.keys(valueObj).length === 1) {
+            receivedParams[key] = valueObj[key];
+          } else {
+            receivedParams[key] = value;
+          }
+        } else {
+          receivedParams[key] = value;
+        }
+      }
+
+      expect(receivedParams).to.deepEqual(normalParams);
+    });
+
+    it('preserves primitive parameters unchanged', () => {
+      const receivedParams: Record<string, unknown> = {};
+
+      const primitiveParams = {
+        name: 'John Doe',
+        age: 30,
+        active: true,
+      };
+
+      for (const [key, value] of Object.entries(primitiveParams)) {
+        if (value && typeof value === 'object') {
+          const valueObj = value as Record<string, unknown>;
+          if (key in valueObj && Object.keys(valueObj).length === 1) {
+            receivedParams[key] = valueObj[key];
+          } else {
+            receivedParams[key] = value;
+          }
+        } else {
+          receivedParams[key] = value;
+        }
+      }
+
+      expect(receivedParams).to.deepEqual(primitiveParams);
+    });
+
+    it('handles array parameters correctly', () => {
+      const receivedParams: Record<string, unknown> = {};
+
+      const arrayParams: Record<string, unknown> = {
+        items: ['item1', 'item2', 'item3'],
+        numbers: [1, 2, 3],
+      };
+
+      for (const [key, value] of Object.entries(arrayParams)) {
+        if (value && typeof value === 'object') {
+          const valueObj = value as Record<string, unknown>;
+          if (key in valueObj && Object.keys(valueObj).length === 1) {
+            receivedParams[key] = valueObj[key];
+          } else {
+            receivedParams[key] = value;
+          }
+        } else {
+          receivedParams[key] = value;
+        }
+      }
+
+      expect(receivedParams).to.deepEqual(arrayParams);
+    });
+
+    it('handles null and undefined parameters', () => {
+      const receivedParams: Record<string, unknown> = {};
+
+      const nullParams = {
+        name: 'John Doe',
+        age: null,
+        address: undefined,
+      };
+
+      for (const [key, value] of Object.entries(nullParams)) {
+        if (value && typeof value === 'object') {
+          const valueObj = value as Record<string, unknown>;
+          if (key in valueObj && Object.keys(valueObj).length === 1) {
+            receivedParams[key] = valueObj[key];
+          } else {
+            receivedParams[key] = value;
+          }
+        } else {
+          receivedParams[key] = value;
+        }
+      }
+
+      expect(receivedParams).to.deepEqual(nullParams);
+    });
+  });
 });

--- a/src/__tests__/integration/mcp-tool.integration.ts
+++ b/src/__tests__/integration/mcp-tool.integration.ts
@@ -3,7 +3,6 @@ import {expect, sinon} from '@loopback/testlab';
 import {McpServerFactory} from '../../services/mcp-server-factory.service';
 import {McpToolRegistry} from '../../services/mcp-tool-registry.service';
 import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
-import {z} from 'zod';
 
 // Test constants to avoid magic numbers
 const TEST_NUMBER_1 = 1;

--- a/src/services/mcp-server-factory.service.ts
+++ b/src/services/mcp-server-factory.service.ts
@@ -38,11 +38,35 @@ export class McpServerFactory {
     const toolDefinitions = this.toolRegistry.getToolDefinitions();
     for (const toolDef of toolDefinitions) {
       // Adapt the registry handler to work with the new API signature
-      // The new API expects (parameters, extra) instead of (context, args, extras)
       const adaptedHandler = async (
         parameters: Record<string, unknown>,
         extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
-      ) => toolDef.handler(this.ctx, parameters, extra);
+      ) => {
+        // Handle common double-wrapping patterns
+        const cleanedParameters: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(parameters)) {
+          if (value && typeof value === 'object') {
+            const valueObj = value as Record<string, unknown>;
+
+            // Pattern: Parameter value wrapped in object with same key
+            // e.g., "currency": {"currency": {...actual data...}}
+            if (key in valueObj && Object.keys(valueObj).length === 1) {
+              cleanedParameters[key] = valueObj[key];
+            } else {
+              cleanedParameters[key] = value;
+            }
+          } else {
+            cleanedParameters[key] = value;
+          }
+        }
+
+        const result = await toolDef.handler(
+          this.ctx,
+          cleanedParameters,
+          extra,
+        );
+        return result;
+      };
 
       // Use the new registerTool API with type assertion to avoid deep type recursion
       const registerTool = (

--- a/src/services/mcp-server-factory.service.ts
+++ b/src/services/mcp-server-factory.service.ts
@@ -45,19 +45,19 @@ export class McpServerFactory {
         // Handle common double-wrapping patterns
         const cleanedParameters: Record<string, unknown> = {};
         for (const [key, value] of Object.entries(parameters)) {
-          if (value && typeof value === 'object') {
-            const valueObj = value as Record<string, unknown>;
-
-            // Pattern: Parameter value wrapped in object with same key
-            // e.g., "currency": {"currency": {...actual data...}}
-            if (key in valueObj && Object.keys(valueObj).length === 1) {
-              cleanedParameters[key] = valueObj[key];
-            } else {
-              cleanedParameters[key] = value;
-            }
-          } else {
+          // Skip non-objects and null/undefined values
+          if (!value || typeof value !== 'object') {
             cleanedParameters[key] = value;
+            continue;
           }
+
+          const valueObj = value as Record<string, unknown>;
+          // Pattern: Parameter value wrapped in object with same key
+          // e.g., "currency": {"currency": {...actual data...}}
+          cleanedParameters[key] =
+            key in valueObj && Object.keys(valueObj).length === 1
+              ? valueObj[key]
+              : value;
         }
 
         const result = await toolDef.handler(


### PR DESCRIPTION
## Description

Support was previously limited to @get methods, and has now been extended to other HTTP methods in mcp-inspector.

While testing, an issue was identified with how the MCP SDK passes object parameters to tools. The SDK automatically introduces an extra layer of nesting, leading to double-wrapped inputs.


https://github.com/user-attachments/assets/85d8a13d-60fc-4403-b072-7887ffb479b1


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
